### PR TITLE
set log level warn by defautl

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ neofs_storage__instance: ''
 # Directory for configuration files and keys
 neofs_storage__conf_dir: "/etc/neofs/storage{{ neofs_storage__instance }}"
 
-neofs_storage__loglevel: 'info'
+neofs_storage__loglevel: 'warning'
 
 # Directory for databases and processing results
 neofs_storage__data_dir: "/var/lib/neofs/neofs-storage{{ neofs_storage__instance }}"


### PR DESCRIPTION
I thought a while and came to the conclusion that default log level should be warning, not info.

Signed-off-by: Sergio Nemirowski <sergio@nspcc.ru>