### PR TITLE
defaults: Add `apiclient` section to `neofs_storage__raw_config`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -113,6 +113,9 @@ neofs_storage__raw_config:
     put:
       pool_size_remote: 100
       pool_size_local: 101
+  apiclient:
+    dial_timeout: 15s
+    stream_timeout: 20s
 
 neofs_storage__default_config:
   - enabled: '{{ neofs_storage__metrics_enabled }}'


### PR DESCRIPTION
Set `dial_timeout` to `15s` and `stream_timeout` to `20s`.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* closes #57